### PR TITLE
ci: Add multi-platform build support to GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/ppc64le,linux/s390x
           tags: |
             ghcr.io/${{ github.repository_owner }}/caddy-cloudflare-docker:${{ github.event.client_payload.latest_version }}
             ghcr.io/${{ github.repository_owner }}/caddy-cloudflare-docker:latest


### PR DESCRIPTION
This pull request adds support for building the Docker image for multiple platforms to ensure broader compatibility.

### Changes:
1. Updated the `build-docker-image.yml` workflow to support multiple platforms.
2. Added support for the following platforms:
   - linux/amd64
   - linux/arm64
   - linux/arm/v7
   - linux/386
   - linux/ppc64le
   - linux/s390x

### Benefits:
- The Docker image will be compatible with a wider range of devices and environments, including ARM-based devices like Raspberry Pi.
- Users will have more flexibility in choosing the appropriate platform for their use case.
