### PR TITLE
feat: Add caddy-combine-ip-ranges module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ FROM caddy:${CADDY_VERSION}-builder AS builder
 # Build Caddy with the Cloudflare DNS module
 RUN xcaddy build \
     --with github.com/caddy-dns/cloudflare \
-    --with github.com/WeidiDeng/caddy-cloudflare-ip
+    --with github.com/WeidiDeng/caddy-cloudflare-ip \
+    --with github.com/fvbommel/caddy-combine-ip-ranges
 
 # Final stage
 FROM caddy:${CADDY_VERSION}

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -5,7 +5,8 @@ FROM caddy:${CADDY_VERSION}-builder-alpine AS builder
 # Build Caddy with the Cloudflare DNS module
 RUN xcaddy build \
     --with github.com/caddy-dns/cloudflare \
-    --with github.com/WeidiDeng/caddy-cloudflare-ip
+    --with github.com/WeidiDeng/caddy-cloudflare-ip \
+    --with github.com/fvbommel/caddy-combine-ip-ranges
 
 # Final stage
 FROM caddy:${CADDY_VERSION}-alpine


### PR DESCRIPTION
This module enables setup like these that are common when using cloudflare tunnels in docker with a reverse proxy:
- https://caddy.community/t/getting-real-ip-on-docker-for-mac/23549/3 
- https://caddy.community/t/multiple-trusted-proxies-directives/23765