### PR TITLE
Upgrade CI actions to latest Node.js versions

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -176,7 +176,7 @@ jobs:
 
       - name: Notify on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const suffix = '${{ inputs.tag_suffix }}' || 'standard';

--- a/.github/workflows/check-caddy-release.yml
+++ b/.github/workflows/check-caddy-release.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.x
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
@@ -47,7 +47,7 @@ jobs:
 
       - name: Trigger Build Workflow if Needed
         if: steps.check_script.outputs.NEEDS_BUILD == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
## Changes

Upgrade GitHub Actions to their latest versions:

- `actions/checkout`: v4 → v6
- `actions/setup-python`: v5 → v6
- `actions/github-script`: v7 → v8

These upgrades ensure the CI pipeline uses the latest Node.js runtime and bug fixes.

## Files Modified

- `.github/workflows/build-docker-image.yml`
- `.github/workflows/check-caddy-release.yml`